### PR TITLE
chore: use GITHUB_AUTH instead of GITHUB_TOKEN

### DIFF
--- a/.release-it.js
+++ b/.release-it.js
@@ -14,6 +14,6 @@ module.exports = {
   github: {
     release: true,
     releaseName: 'Release ${version}',
-    tokenRef: 'GITHUB_TOKEN',
+    tokenRef: 'GITHUB_AUTH',
   },
 };


### PR DESCRIPTION
In order to be compatible with lerna changelog, and having the a unique env variable for both tools.