### PR TITLE
💥 Drop node 8 support 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 8.x
+          node-version: 10.x
       - name: Install dependencies
         run: yarn --frozen-lockfile
       - name: Lint javascript code
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 8.x
+          node-version: 10.x
       - name: Install dependencies
         run: yarn --frozen-lockfile
       - name: Run tests
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 8.x
+          node-version: 10.x
       - name: Install dependencies
         run: yarn --frozen-lockfile
       - name: Run tests for ember-${{ matrix.ember }}
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 8.x
+          node-version: 10.x
       - name: Install dependencies w/o lockfile
         run: yarn install --no-lockfile --non-interactive
       - name: Run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "8"
+  - "10"
 
 sudo: false
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "release-it": "^12.4.3"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": "10.* || >= 12.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
#### Description
This PR aims to drop `node 8` support as it has reaches is end of life
see https://nodejs.org/en/about/releases/

#### Changes
[//]: # "Add if relevant, remove if not"
* Update `package.json` to udpdate engines
* Update `.travis-ci.yml`