### PR TITLE
chore: update lerna-changelog labels for proper changelogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,17 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"
+  },
+  "changelog": {
+    "labels": {
+      "breaking": ":boom: Breaking Change",
+      "bug": ":bug: Bug Fixes",
+      "dependencies": ":pushpin: Dependency",
+      "documentation": ":pencil: Documentation",
+      "enhancement": ":zap: Improvement Features",
+      "internal": ":house-with-garden: Dependency",
+      "refactoring": ":shirt: Refactoring",
+      "security": ":lock: Security Fixes"
+    }
   }
 }


### PR DESCRIPTION
The changelog was not properly updated, as the maping with github labels wasn't done yet.

This MR fixes it.