### PR TITLE
Add default support for textarea elements

### DIFF
--- a/addon/modifiers/autofocus.js
+++ b/addon/modifiers/autofocus.js
@@ -1,6 +1,8 @@
 import { modifier } from 'ember-modifier';
 
-export default modifier(function autofocus(element, [selector = 'input:not([disabled])']) {
+const DEFAULT_SELECTOR = 'input:not([disabled]),textarea:not([disabled])';
+
+export default modifier(function autofocus(element, [selector = DEFAULT_SELECTOR]) {
   const childElement = element.querySelector(selector);
 
   if (childElement) {

--- a/tests/integration/modifiers/autofocus-test.js
+++ b/tests/integration/modifiers/autofocus-test.js
@@ -97,4 +97,16 @@ module('Integration | Modifier | autofocus', function(hooks) {
 
     assert.dom('[data-test-input-6]').isFocused('The custom selected element is focused');
   });
+
+  test('should give focus to the first included textarea that is not disabled', async function(assert) {
+    await render(hbs`
+      <form {{autofocus}}>
+        <textarea data-test-textarea="disabled" disabled />
+        <textarea data-test-textarea="enabled" />
+        <input data-test-input="enabled" />
+      </form>
+    `);
+
+    assert.dom('[data-test-textarea="enabled"]').isFocused('The first enabled textarea is focused');
+  });
 });


### PR DESCRIPTION
Hi, thanks for the modifier!

Thought it would be nice if the modifier supports textarea elements as well by default.
I couldn't find any related ticket or PR so I wasn't sure if support for textarea elements was omitted for a specific reason.
It seems to make sense to me, so thought I'd make a PR for it.
It's a behavioural change though, so might be "breaking" in some cases. As in, suddenly a textarea element has been given focus.