### PR TITLE
Add ember 3.4 to ember-try scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     needs: [lint, basic-tests]
     strategy:
       matrix:
-        ember: [lts-3.8, lts-3.12, lts-3.16, lts-3.24, release, beta, canary]
+        ember: [lts-3.4, lts-3.8, lts-3.12, lts-3.16, lts-3.24, release, beta, canary]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,6 +8,14 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
+        name: 'ember-lts-3.4',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.4.0',
+          },
+        },
+      },
+      {
         name: 'ember-lts-3.8',
         npm: {
           devDependencies: {


### PR DESCRIPTION
We state support for ember 3.4, so we should test against it.