### PR TITLE
Drop support for Ember < 3.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     needs: [lint, basic-tests]
     strategy:
       matrix:
-        ember: [lts-3.8, lts-3.12, lts-3.16, lts-3.24, release, beta, canary]
+        ember: [lts-3.24, release, beta, canary]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ npm install --save-dev ember-autofocus-modifier
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v3.4 or above
+* Ember.js v3.24 or above
 * Ember CLI v2.13 or above
 * Node.js v12 or above
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,38 +8,6 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.8',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.8.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.12',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.12.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.16',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.16.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.20',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.20.5',
-          },
-        },
-      },
-      {
         name: 'ember-lts-3.24',
         npm: {
           devDependencies: {

--- a/package.json
+++ b/package.json
@@ -50,8 +50,6 @@
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
-    "ember-compatibility-helpers": "^1.2.5",
-    "ember-decorators-polyfill": "^1.1.5",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^2.1.2",

--- a/tests/integration/modifiers/autofocus-test.js
+++ b/tests/integration/modifiers/autofocus-test.js
@@ -1,7 +1,6 @@
 import { render } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import { gte } from 'ember-compatibility-helpers';
 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -205,41 +204,39 @@ module('Integration | Modifier | autofocus', function (hooks) {
       .isNotFocused('The third non related input are not focused');
   });
 
-  if (gte('3.16.0')) {
-    test('should not cause rerender assertions on Glimmer components when a focus modifier is present', async function (assert) {
-      class FooButtonComponent extends Component {
-        @tracked bar;
+  test('should not cause rerender assertions on Glimmer components when a focus modifier is present', async function (assert) {
+    class FooButtonComponent extends Component {
+      @tracked bar;
 
-        @action
-        updateBar() {
-          this.bar = !this.bar;
-        }
+      @action
+      updateBar() {
+        this.bar = !this.bar;
       }
-      setComponentTemplate(
-        hbs`
-        <button
-          {{on "focus" this.updateBar}}
-          ...attributes
-        >
-          Foo: {{this.bar}}
-        </button>
-      `,
-        FooButtonComponent
-      );
-      this.owner.register('component:foo-button', FooButtonComponent);
+    }
+    setComponentTemplate(
+      hbs`
+      <button
+        {{on "focus" this.updateBar}}
+        ...attributes
+      >
+        Foo: {{this.bar}}
+      </button>
+    `,
+      FooButtonComponent
+    );
+    this.owner.register('component:foo-button', FooButtonComponent);
 
-      await render(hbs`
-        <div {{autofocus "input,button"}}>
-          <span>this is not a focusable element</span>
-          <FooButton data-test-foo/>
-          <input data-test-input-1 />
-        </div>
-      `);
+    await render(hbs`
+      <div {{autofocus "input,button"}}>
+        <span>this is not a focusable element</span>
+        <FooButton data-test-foo/>
+        <input data-test-input-1 />
+      </div>
+    `);
 
-      assert.dom('[data-test-foo]').isFocused('The button element is focused');
-      assert
-        .dom('[data-test-input-1]')
-        .isNotFocused('The first non related input is not focused');
-    });
-  }
+    assert.dom('[data-test-foo]').isFocused('The button element is focused');
+    assert
+      .dom('[data-test-input-1]')
+      .isNotFocused('The first non related input is not focused');
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6786,7 +6786,7 @@ ember-cli-babel@^6.0.0-beta.4:
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
   version "7.26.6"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz#322fbbd3baad9dd99e3276ff05bc6faef5e54b39"
   integrity sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==
@@ -7109,7 +7109,7 @@ ember-cli@~3.28.4:
     workerpool "^6.1.4"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.5:
+ember-compatibility-helpers@^1.1.2:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.5.tgz#b8363b1d5b8725afa9a4fe2b2986ac28626c6f23"
   integrity sha512-7cddkQQp8Rs2Mqrj0xqZ0uO7eC9tBCKyZNcP2iE1RxQqOGPv8fiPkj1TUeidUB/Qe80lstoVXWMEuqqhW7Yy9A==
@@ -7128,15 +7128,6 @@ ember-compatibility-helpers@^1.2.0, ember-compatibility-helpers@^1.2.1, ember-co
     ember-cli-version-checker "^5.1.1"
     fs-extra "^9.1.0"
     semver "^5.4.1"
-
-ember-decorators-polyfill@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/ember-decorators-polyfill/-/ember-decorators-polyfill-1.1.5.tgz#49203c302ea4486618ba4866923ec657cf2c9f3d"
-  integrity sha512-O154i8sLoVjsiKzSqxGRfHGr+N+drT6mRrLDbNgJCnW/V5uLg/ppZFpUsrdxuXnp5Q9us3OfXV1nX2CH+7bUpA==
-  dependencies:
-    ember-cli-babel "^7.1.2"
-    ember-cli-version-checker "^3.1.3"
-    ember-compatibility-helpers "^1.2.0"
 
 ember-destroyable-polyfill@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
This drops support for Ember < 3.24. This is in line with the compatibility of [ember-modifier](https://github.com/ember-modifier/ember-modifier) allowing us to upgrade to ember-modifier v3 after this is merged.