### PR TITLE
Add readonly to default selector

### DIFF
--- a/addon/modifiers/autofocus.js
+++ b/addon/modifiers/autofocus.js
@@ -1,7 +1,8 @@
 import { modifier } from 'ember-modifier';
 import { next } from '@ember/runloop';
 
-const DEFAULT_SELECTOR = 'input:not([disabled]),textarea:not([disabled])';
+const DEFAULT_SELECTOR =
+  'input:not([disabled]):not([readonly]),textarea:not([disabled]):not([readonly])';
 
 export default modifier(function autofocus(
   element,

--- a/tests/integration/modifiers/autofocus-test.js
+++ b/tests/integration/modifiers/autofocus-test.js
@@ -42,6 +42,22 @@ module('Integration | Modifier | autofocus', function (hooks) {
       .isFocused('The first enabled input is focused');
   });
 
+  test('should focus the first included input that is not readonly', async function (assert) {
+    await render(hbs`
+      <div {{autofocus}}>
+        <span>this is not a focusable element</span>
+        <button data-test-button>this is a button</button>
+        <input data-test-input-1 readonly />
+        <input data-test-input-2 readonly />
+        <input data-test-input-3 />
+      </div>
+    `);
+
+    assert
+      .dom('[data-test-input-3]')
+      .isFocused('The first enabled input is focused');
+  });
+
   test('should focus the root element if no children are found', async function (assert) {
     await render(hbs`
       <input data-test-input {{autofocus}} />
@@ -119,6 +135,20 @@ module('Integration | Modifier | autofocus', function (hooks) {
     await render(hbs`
       <form {{autofocus}}>
         <textarea data-test-textarea="disabled" disabled />
+        <textarea data-test-textarea="enabled" />
+        <input data-test-input="enabled" />
+      </form>
+    `);
+
+    assert
+      .dom('[data-test-textarea="enabled"]')
+      .isFocused('The first enabled textarea is focused');
+  });
+
+  test('should give focus to the first included textarea that is not readonly', async function (assert) {
+    await render(hbs`
+      <form {{autofocus}}>
+        <textarea data-test-textarea="readonly" readonly />
         <textarea data-test-textarea="enabled" />
         <input data-test-input="enabled" />
       </form>


### PR DESCRIPTION
This PR aims to add the support for the attribute [`readonly`](https://www.w3.org/TR/2010/WD-html5-20101019/common-input-element-attributes.html#attr-input-readonly), where only the `disabled` case was handled.



