### PR TITLE
Support A11y workflow where we want to move focus, yet still omit non…

### DIFF
--- a/addon/modifiers/autofocus.js
+++ b/addon/modifiers/autofocus.js
@@ -1,6 +1,15 @@
 import { modifier } from 'ember-modifier';
 import { next } from '@ember/runloop';
 
+const focusableElements = [
+  'BUTTON',
+  'SUMMARY',
+  'IFRAME',
+  'INPUT',
+  'SELECT',
+  'TEXTAREA',
+];
+
 const DEFAULT_SELECTOR =
   'input:not([disabled]):not([readonly]),textarea:not([disabled]):not([readonly])';
 
@@ -10,15 +19,52 @@ export default modifier(
       return;
     }
 
-    const childElement = element.querySelector(selector);
+    // Instead of selecting a child element by default, should this (in a major),
+    // be a behavior that is changed via a passed flag?
+    const targetElement = element.querySelector(selector) || element;
+    const isChildElement = targetElement !== element;
+
+    /**
+     * Only applies to the element that {{autofocus}} is applied to.
+     * opts-out if we're selecting a child element.
+     */
+    const shouldMoveFocus =
+      !isChildElement &&
+      !focusableElements.some(
+        (item) =>
+          element.tagName === item ||
+          element.isContentEditable ||
+          element.hasAttribute('aria-disabled') ||
+          element.hasAttribute('href') ||
+          element.hasAttribute('tabindex')
+      );
+
+    /**
+     * if {{autofocus}} is applied to a non-focusable element,
+     * For A11y purposes, this is used to move focus to the non-focusable element.
+     * This is helpful when new elements are inserted on to the screen (yet not focus-trapped),
+     * and we want the tab-behavior to move "near" the inserted content.
+     *
+     * This still prevents the non-focusable element from being tabbed to, as non-focusable
+     * elements are still not focusable.
+     *
+     * But this is a behavior we can use to help out screen readers and keyboard users alike to
+     * more smoothly interact with newly-inserted content (without needing to focus an interactive-specifically
+     * maybe the inserted contents are just buttons, for example).
+     */
+    if (shouldMoveFocus) {
+      element.setAttribute('tabindex', '-1');
+    }
 
     next(function () {
-      if (childElement) {
-        childElement.focus();
-      } else {
-        element.focus();
-      }
+      targetElement.focus();
     });
+
+    return () => {
+      if (shouldMoveFocus) {
+        element.removeAttribute('tabindex');
+      }
+    };
   },
   { eager: false }
 );

--- a/tests/integration/modifiers/autofocus-test.js
+++ b/tests/integration/modifiers/autofocus-test.js
@@ -1,4 +1,4 @@
-import { render } from '@ember/test-helpers';
+import { find, render } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -268,5 +268,60 @@ module('Integration | Modifier | autofocus', function (hooks) {
     assert
       .dom('[data-test-input-1]')
       .isNotFocused('The first non related input is not focused');
+  });
+
+  module('A11y-specific behaviors', function () {
+    test('non-focusable elements may be focused', async function (assert) {
+      await render(hbs`<div {{autofocus}}></div>`);
+
+      assert.dom('div').isFocused();
+      assert.dom('div').hasAttribute('tabindex', '-1');
+    });
+
+    test('tabindex isnt added to already focusable elements', async function (assert) {
+      let assertElement = (element) => {
+        let elem = find(element);
+
+        assert.dom(elem).isFocused();
+        assert.dom(elem).doesNotHaveAttribute('tabindex');
+      };
+
+      await render(hbs`<button aria-disabled {{autofocus}}></button>`);
+      assertElement('[aria-disabled]');
+
+      await render(hbs`<button {{autofocus}}></button>`);
+      assertElement('button');
+
+      await render(hbs`
+        <details>
+          <summary {{autofocus}}></summary>
+        </details>
+      `);
+      assertElement('summary');
+
+      await render(hbs`<iframe {{autofocus}}></iframe>`);
+      assertElement('iframe');
+
+      await render(hbs`<input {{autofocus}} />`);
+      assertElement('input');
+
+      await render(hbs`<select {{autofocus}}></select>`);
+      assertElement('select');
+
+      await render(hbs`<textarea {{autofocus}}></textarea>`);
+      assertElement('textarea');
+
+      await render(hbs`<a href {{autofocus}}></a>`);
+      assertElement('[href]');
+
+      await render(hbs`<div contenteditable {{autofocus}}></div>`);
+      assertElement('[contenteditable]');
+    });
+    test('it respects existing tabindex', async function (assert) {
+      await render(hbs`<div tabindex="0" {{autofocus}}></div>`);
+
+      assert.dom('div').isFocused();
+      assert.dom('div').hasAttribute('tabindex', '0');
+    });
   });
 });

--- a/tests/integration/modifiers/autofocus-test.js
+++ b/tests/integration/modifiers/autofocus-test.js
@@ -1,4 +1,4 @@
-import { find, render } from '@ember/test-helpers';
+import { find, render, tab } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -276,6 +276,41 @@ module('Integration | Modifier | autofocus', function (hooks) {
 
       assert.dom('div').isFocused();
       assert.dom('div').hasAttribute('tabindex', '-1');
+    });
+
+    test('non-focusable {{autofocus}} elements are still omitted from tabbing', async function (assert) {
+      await render(hbs`
+        <div {{autofocus}}></div>
+        <button id='a'></button>
+        <button id='b'></button>
+      `);
+
+      assert.dom('div').isFocused();
+
+      await tab();
+      assert.dom('div').isNotFocused();
+      assert.dom('#a').isFocused();
+
+      await tab();
+      assert.dom('#a').isNotFocused();
+      assert.dom('#b').isFocused();
+
+      await tab();
+      assert.dom('#a').isNotFocused();
+      assert.dom('div').isNotFocused();
+
+      await tab({ backwards: true });
+      assert.dom('#b').isFocused();
+      assert.dom('div').isNotFocused();
+
+      await tab({ backwards: true });
+      assert.dom('#b').isNotFocused();
+      assert.dom('#a').isFocused();
+      assert.dom('div').isNotFocused();
+
+      await tab({ backwards: true });
+      assert.dom('#a').isNotFocused();
+      assert.dom('div').isNotFocused();
     });
 
     test('tabindex isnt added to already focusable elements', async function (assert) {


### PR DESCRIPTION
…-focusable elements from tab-order


if {{autofocus}} is applied to a non-focusable element,
For A11y purposes, this is used to move focus to the non-focusable element.
This is helpful when new elements are inserted on to the screen (yet not focus-trapped),
and we want the tab-behavior to move "near" the inserted content.

This still prevents the non-focusable element from being tabbed to, as non-focusable
elements are still not focusable.

But this is a behavior we can use to help out screen readers and keyboard users alike to
more smoothly interact with newly-inserted content (without needing to focus an interactive-specifically
maybe the inserted contents are just buttons, for example).
