### PR TITLE
fix: remove double node installation on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
       - name: Install pnpm
         uses: NullVoxPopuli/action-setup-pnpm@v2
         with:
           pnpm-version: 8.5.1
+          node-version: 16.x
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Lint
@@ -41,14 +38,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
       - name: Install pnpm
         uses: NullVoxPopuli/action-setup-pnpm@v2
         with:
           pnpm-version: 8.5.1
+          node-version: 16.x
       - name: Install dependencies
         run: pnpm install --no-lockfile
       - name: Run tests
@@ -74,14 +68,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
       - name: Install pnpm
         uses: NullVoxPopuli/action-setup-pnpm@v2
         with:
           pnpm-version: 8.5.1
+          node-version: 16.x
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run tests


### PR DESCRIPTION
`NullVoxPopuli/action-setup-pnpm` already handles the node setup. So we were running `actions/setup-node` twice.