### PR TITLE
ci: add support to execute workflow manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - main
       - master
   pull_request: {}
+  workflow_dispatch: {}
 
 concurrency:
   group: ci-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
To properly debug [this PR](https://github.com/qonto/ember-autofocus-modifier/pull/396), I need to manually execute the CI workflow on the master branch.

The change done here, adds support for manual workflow execution, as written in the GitHub doc: https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow#configuring-a-workflow-to-run-manually