### PR TITLE
chore: adding missing dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    versioning-strategy: increase


### PR DESCRIPTION
This PR adds explicit dependabot configuration as in https://github.com/qonto/ember-amount-input/blob/master/.github/dependabot.yml. 

This _should_ fix also the problem with the current setup, since the last PR opened by dependabot was from March.