### PR TITLE
chore: update dependabot interval to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
     open-pull-requests-limit: 10
     labels:
       - dependencies


### PR DESCRIPTION
Updating the `interval` to `daily` so that we can test the new dependabot configuration quickly