### PR TITLE
chore: change dependabot conf to weekly interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
     labels:
       - dependencies


### PR DESCRIPTION
Related to https://github.com/qonto/ember-autofocus-modifier/pull/402.

Changing back the dependabot interval to `weekly` since the new configuration is now working.