### PR TITLE
chore: add .prettierignore to ember-autofocus-modifier

### DIFF
--- a/ember-autofocus-modifier/.prettierignore
+++ b/ember-autofocus-modifier/.prettierignore
@@ -1,0 +1,25 @@
+# unconventional js
+/blueprints/*/files/
+/vendor/
+
+# compiled output
+/dist/
+/tmp/
+
+# dependencies
+/bower_components/
+/node_modules/
+
+# misc
+/coverage/
+!.*
+.eslintcache
+.lint-todo/
+
+# ember-try
+/.node_modules.ember-try/
+/bower.json.ember-try
+/npm-shrinkwrap.json.ember-try
+/package.json.ember-try
+/package-lock.json.ember-try
+/yarn.lock.ember-try


### PR DESCRIPTION
Adding the `.prettierignore` file to `ember-autofocus-modifier`.

This will be used subsequently in the following pull request: https://github.com/qonto/ember-autofocus-modifier/pull/432