### PR TITLE
chore: remove ember-source v5 from peerDependencies

### DIFF
--- a/ember-autofocus-modifier/package.json
+++ b/ember-autofocus-modifier/package.json
@@ -54,7 +54,7 @@
     "rollup-plugin-copy": "^3.5.0"
   },
   "peerDependencies": {
-    "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
+    "ember-source": "^3.28.0 || ^4.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(ember-source@4.12.0)
       ember-source:
-        specifier: ^3.28.0 || ^4.0.0 || ^5.0.0
+        specifier: ^3.28.0 || ^4.0.0
         version: 4.12.0(@babel/core@7.23.0)(@glimmer/component@1.1.2)(webpack@5.88.2)
     devDependencies:
       '@babel/core':


### PR DESCRIPTION
Removing `ember-source@5` from `peerDepencies` since we had multiple problems with it in the following PRs:

- https://github.com/qonto/ember-autofocus-modifier/pull/431
- https://github.com/qonto/ember-autofocus-modifier/pull/415