### PR TITLE
chore: update test-app to ember-source@5.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
         ember-try-scenario:
           - ember-lts-3.28
           - ember-lts-4.4
+          - ember-lts-4.8
+          - ember-lts-4.12
           - ember-release
           - ember-beta
           - ember-canary

--- a/package.json
+++ b/package.json
@@ -50,5 +50,10 @@
       "tokenRef": "GITHUB_AUTH"
     },
     "npm": false
+  },
+  "pnpm": {
+    "overrides": {
+      "ember-source": "4.12.0"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  ember-source: 4.12.0
+
 importers:
 
   .:

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -32,6 +32,22 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-lts-4.8',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.8.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-4.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.12.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -57,7 +57,7 @@
     "ember-page-title": "8.0.0",
     "ember-qunit": "8.0.1",
     "ember-resolver": "11.0.1",
-    "ember-source": "4.12.0",
+    "ember-source": "5.3.0",
     "ember-source-channel-url": "3.0.0",
     "ember-template-lint": "5.11.2",
     "ember-try": "2.0.0",


### PR DESCRIPTION
In this Pull Request I'm doing the following:

- Update test-app to `ember-source@5.3.0`. I was previously adding this here https://github.com/qonto/ember-autofocus-modifier/pull/447, but better to split this for added control and better review (e.g.: in case of revert a separate PR could be easier to manage)
- Add missing ember-try test scenarios for ember LTS version prior to `5.3.0`
- The override done on the root package.json is required to fix [this problem](https://github.com/qonto/ember-autofocus-modifier/actions/runs/6494674434/job/17638109873?pr=447#step:4:268) on the CI related to `embroider-*` jobs. This is recommended by the embroider docs: https://github.com/embroider-build/embroider/blob/main/docs/peer-dependency-resolution-issues.md