### PR TITLE
chore: extract release-it config to own file

### DIFF
--- a/.release-it.js
+++ b/.release-it.js
@@ -1,0 +1,17 @@
+module.exports = {
+  plugins: {
+    "@release-it-plugins/lerna-changelog": {
+      infile: "CHANGELOG.md",
+      launchEditor: false,
+    },
+    "@release-it-plugins/workspaces": true,
+  },
+  git: {
+    tagName: "v${version}",
+  },
+  github: {
+    release: true,
+    tokenRef: "GITHUB_AUTH",
+  },
+  npm: false,
+};

--- a/package.json
+++ b/package.json
@@ -39,23 +39,6 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },
-  "release-it": {
-    "plugins": {
-      "@release-it-plugins/lerna-changelog": {
-        "infile": "CHANGELOG.md",
-        "launchEditor": false
-      },
-      "@release-it-plugins/workspaces": true
-    },
-    "git": {
-      "tagName": "v${version}"
-    },
-    "github": {
-      "release": true,
-      "tokenRef": "GITHUB_AUTH"
-    },
-    "npm": false
-  },
   "pnpm": {
     "overrides": {
       "ember-source": "4.12.2"


### PR DESCRIPTION
To avoid overcomplicating the `package.json` file, we extract `release-it` configuration block to its own file.