### PR TITLE
chore: use packageManager entry in package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Install pnpm
         uses: wyvox/action-setup-pnpm@v3
         with:
-          pnpm-version: 8.5.1
           node-version: 18.x
           args: "--frozen-lockfile"
       - name: Lint
@@ -40,7 +39,6 @@ jobs:
       - name: Install pnpm
         uses: wyvox/action-setup-pnpm@v3
         with:
-          pnpm-version: 8.5.1
           node-version: 18.x
           args: "--no-lockfile"
       - name: Run tests
@@ -71,7 +69,6 @@ jobs:
       - name: Install pnpm
         uses: wyvox/action-setup-pnpm@v3
         with:
-          pnpm-version: 8.5.1
           node-version: 18.x
           args: "--frozen-lockfile"
       - name: Run tests
@@ -99,7 +96,6 @@ jobs:
       - name: Install pnpm
         uses: wyvox/action-setup-pnpm@v3
         with:
-          pnpm-version: 8.5.1
           node-version: 18.x
           args: "--frozen-lockfile"
       - name: Update TS version on addon package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Install pnpm
         uses: wyvox/action-setup-pnpm@v3
         with:
-          pnpm-version: 8.5.1
           node-version: 18.x
           node-registry-url: "https://registry.npmjs.org"
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },
+  "packageManager": "pnpm@8.11.0",
   "pnpm": {
     "overrides": {
       "ember-source": "4.12.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   ember-source: 4.12.2
 
@@ -41,7 +45,7 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(ember-source@4.12.2)
       ember-source:
-        specifier: ^3.28.0 || ^4.0.0 || ^5.0.0
+        specifier: 4.12.2
         version: 4.12.2(@babel/core@7.23.0)(@glimmer/component@1.1.2)(@glint/template@1.2.1)(webpack@5.88.2)
     devDependencies:
       '@babel/core':
@@ -1746,7 +1750,7 @@ packages:
     resolution: {integrity: sha512-DvJSihJPV4xshwEgBrFN4aUVc9m/Y/hVzwcslfSVq/h3dMWCyAj4+agkkdJPQrwBaE+H4IyGNzr555S7bTErEA==}
     engines: {node: 16.* || >= 18}
     peerDependencies:
-      ember-source: ^4.0.0 || ^5.0.0
+      ember-source: 4.12.2
     dependencies:
       '@ember/test-waiters': 3.0.2
       '@embroider/macros': 1.13.0(@glint/template@1.2.1)
@@ -6228,7 +6232,7 @@ packages:
     resolution: {integrity: sha512-XA1FwkWA5QytmWF0jcJqEr3jcZoiCl9Fb33TZgOVfClL7Voxe+/RwzISEprBRQgbf7j8z1xf8/RJCKfclUy3rQ==}
     engines: {node: 14.* || 16.* || >= 18}
     peerDependencies:
-      ember-source: ^3.28.0 || >= 4.0.0
+      ember-source: 4.12.2
     dependencies:
       ember-cli-babel: 7.26.11
       ember-source: 4.12.2(@babel/core@7.23.0)(@glimmer/component@1.1.2)(@glint/template@1.2.1)(webpack@5.88.2)
@@ -6721,7 +6725,7 @@ packages:
   /ember-modifier@4.1.0(ember-source@4.12.2):
     resolution: {integrity: sha512-YFCNpEYj6jdyy3EjslRb2ehNiDvaOrXTilR9+ngq+iUqSHYto2zKV0rleiA1XJQ27ELM1q8RihT29U6Lq5EyqQ==}
     peerDependencies:
-      ember-source: '*'
+      ember-source: 4.12.2
     peerDependenciesMeta:
       ember-source:
         optional: true
@@ -6746,7 +6750,7 @@ packages:
     resolution: {integrity: sha512-13PtywHNPTQKkDW4o8QRkJvcdsZr8hRyvh6xh/YLAX8+HaRLd3nPL8mBF4O/Kur/DAj3QWLvjzktZ2uRNGSh3A==}
     peerDependencies:
       '@ember/test-helpers': '>=3.0.3'
-      ember-source: '>=4.0.0'
+      ember-source: 4.12.2
       qunit: ^2.13.0
     dependencies:
       '@ember/test-helpers': 3.2.1(@glint/template@1.2.1)(ember-source@4.12.2)(webpack@5.88.2)
@@ -6764,7 +6768,7 @@ packages:
     resolution: {integrity: sha512-ucBk3oM+PR+AfYoSUXeQh8cDQS1sSiEKp4Pcgbew5cFMSqPxJfqd1zyZsfQKNTuyubeGmWxBOyMVSTvX2LeCyg==}
     engines: {node: 14.* || 16.* || >= 18}
     peerDependencies:
-      ember-source: ^4.8.3 || >= 5.0.0
+      ember-source: 4.12.2
     peerDependenciesMeta:
       ember-source:
         optional: true
@@ -14392,7 +14396,3 @@ packages:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
This MR adds a packageManager entry in the package.json to pin pnpm's version. This avoids duplication in CI workflows and hint multiple tools to use a specific pnpm version. (action-setup-pnpm, dependabot, corepack, etc...) 