### PR TITLE
fix(type): positional argument should extend `Array<any>`

### DIFF
--- a/ember-autofocus-modifier/src/modifiers/autofocus.ts
+++ b/ember-autofocus-modifier/src/modifiers/autofocus.ts
@@ -16,7 +16,7 @@ const DEFAULT_SELECTOR =
 interface ModifierArgs {
   Element: HTMLElement;
   Args: {
-    Positional: [string?] | undefined; // Optional selector
+    Positional: [string?]; // Optional selector
     Named: {
       disabled?: boolean; // Optional 'disabled' parameter
     };

--- a/test-app/tests/integration/modifiers/autofocus-test.ts
+++ b/test-app/tests/integration/modifiers/autofocus-test.ts
@@ -181,7 +181,7 @@ module('Integration | Modifier | autofocus', function (hooks) {
 
   test('should not focus due to disabled parameter set to true without providing a selector', async function (assert) {
     await render(hbs`
-      <div {{autofocus disabled=true}}>
+      <div {{autofocus "input" disabled=true}}>
         <span>this is not a focusable element</span>
         <button type="button" data-test-button>this is a button</button>
         <input id="1" data-test-input-1 />
@@ -206,7 +206,7 @@ module('Integration | Modifier | autofocus', function (hooks) {
 
   test('should focus due to disabled parameter set to false', async function (assert) {
     await render(hbs`
-      <div {{autofocus disabled=false}}>
+      <div {{autofocus "input" disabled=false}}>
         <span>this is not a focusable element</span>
         <button type="button" data-test-button>this is a button</button>
         <input id="1" data-test-input-1 />


### PR DESCRIPTION
This PR tries to solve https://github.com/qonto/ember-autofocus-modifier/issues/522.

The fix has 2 main points.

First, the `Positional` argument should extend `Array<any>`. Therefore, it cannot be `undefined`. The first fix corresponds to:

```diff
- Positional: [string?] | undefined;
+ Positional: [string?];
```

This should resolve https://github.com/qonto/ember-autofocus-modifier/issues/522.

Then, by doing so, we encounter a type error in our integration tests file when we do something like:

```ts
<div {{autofocus disabled=false}}>
```

The error is: `Argument of type '{ [NamedArgs]: true; disabled: boolean; }' is not assignable to parameter of type 'string'.`

The issue we encounter is explained [here](https://github.com/typed-ember/glint/discussions/627#discussioncomment-7188233), and the error is basically due to the fact that optional positional arguments are not supported. The actual type our signature represents is something like this:

```ts
function autofocus(
  s?: string,
  options: { disabled?: boolean }
): void;
```

Which is wrong as a required parameter cannot follow an optional parameter. So, in our case, if we want to use the disabled named argument, we should also provide the positional argument with the tag of the element as a `string`.