### PR TITLE
chore: dedupe pnpm lock file

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1898,23 +1898,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@embroider/shared-internals@2.5.1:
-    resolution: {integrity: sha512-b+TWDBisH1p6HeTbJIO8pgu1WzfTP0ZSAlZBqjXwOyrS0ZxP1qNYRrEX+IxyzIibEFjXBxeLakiejz3DJvZX5A==}
-    engines: {node: 12.* || 14.* || >= 16}
-    dependencies:
-      babel-import-util: 2.0.1
-      debug: 4.3.4
-      ember-rfc176-data: 0.3.18
-      fs-extra: 9.1.0
-      js-string-escape: 1.0.1
-      lodash: 4.17.21
-      resolve-package-path: 4.0.3
-      semver: 7.6.3
-      typescript-memoize: 1.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@embroider/shared-internals@2.5.2:
     resolution: {integrity: sha512-jNDJ9YlV6Qp9Na9v17qirUewVuq6T0t32nn+bbnFlCRTvmllKluZdYPSC5RuRnEZKTloVYRSF0+f1rgkTIEvxQ==}
     engines: {node: 12.* || 14.* || >= 16}
@@ -2228,6 +2211,7 @@ packages:
   /@humanwhocodes/config-array@0.11.13:
     resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 2.0.1
       debug: 4.3.4
@@ -2243,6 +2227,7 @@ packages:
 
   /@humanwhocodes/object-schema@2.0.1:
     resolution: {integrity: sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==}
+    deprecated: Use @eslint/object-schema instead
     dev: true
 
   /@hutson/parse-repository-url@5.0.0:
@@ -2542,7 +2527,7 @@ packages:
       detect-indent: 6.1.0
       detect-newline: 3.1.0
       release-it: 16.3.0(typescript@5.6.2)
-      semver: 7.5.4
+      semver: 7.6.3
       url-join: 4.0.1
       validate-peer-dependencies: 1.2.0
       walk-sync: 2.2.0
@@ -2847,21 +2832,43 @@ packages:
       '@types/node': 20.8.4
     dev: true
 
+  /@types/ember@4.0.6:
+    resolution: {integrity: sha512-5CAqPP20l1CWXT1E0NoiBnQUKqwuPSBq0JJVadEIX65CUzVz3zUIFvNoSl1erePwOeCIiQn9pHa568XwZnD6Mw==}
+    dependencies:
+      '@types/ember__application': 4.0.8(@babel/core@7.23.9)
+      '@types/ember__array': 4.0.6(@babel/core@7.23.9)
+      '@types/ember__component': 4.0.22
+      '@types/ember__controller': 4.0.8
+      '@types/ember__debug': 4.0.5
+      '@types/ember__engine': 4.0.7
+      '@types/ember__error': 4.0.3
+      '@types/ember__object': 4.0.8
+      '@types/ember__polyfills': 4.0.3
+      '@types/ember__routing': 4.0.16
+      '@types/ember__runloop': 4.0.6
+      '@types/ember__service': 4.0.5
+      '@types/ember__string': 3.0.11
+      '@types/ember__template': 4.0.3
+      '@types/ember__test': 4.0.3(@babel/core@7.23.9)
+      '@types/ember__utils': 4.0.4
+      '@types/rsvp': 4.0.5
+    dev: true
+
   /@types/ember@4.0.6(@babel/core@7.23.9):
     resolution: {integrity: sha512-5CAqPP20l1CWXT1E0NoiBnQUKqwuPSBq0JJVadEIX65CUzVz3zUIFvNoSl1erePwOeCIiQn9pHa568XwZnD6Mw==}
     dependencies:
       '@types/ember__application': 4.0.8(@babel/core@7.23.9)
       '@types/ember__array': 4.0.6(@babel/core@7.23.9)
       '@types/ember__component': 4.0.22(@babel/core@7.23.9)
-      '@types/ember__controller': 4.0.8(@babel/core@7.23.9)
-      '@types/ember__debug': 4.0.5(@babel/core@7.23.9)
-      '@types/ember__engine': 4.0.7(@babel/core@7.23.9)
+      '@types/ember__controller': 4.0.8
+      '@types/ember__debug': 4.0.5
+      '@types/ember__engine': 4.0.7
       '@types/ember__error': 4.0.3
       '@types/ember__object': 4.0.8(@babel/core@7.23.9)
       '@types/ember__polyfills': 4.0.3
       '@types/ember__routing': 4.0.16(@babel/core@7.23.9)
       '@types/ember__runloop': 4.0.6(@babel/core@7.23.9)
-      '@types/ember__service': 4.0.5(@babel/core@7.23.9)
+      '@types/ember__service': 4.0.5
       '@types/ember__string': 3.0.11
       '@types/ember__template': 4.0.3
       '@types/ember__test': 4.0.3(@babel/core@7.23.9)
@@ -2876,11 +2883,11 @@ packages:
     resolution: {integrity: sha512-ruOQCPO4NrGsraja52wbu0lX/oXQxPvUc6pNr7v/5Lix6UdV3jkP9RW3HwWljMEj48gcCvIwuTt0HfIha4T0GQ==}
     dependencies:
       '@glimmer/component': 1.1.2(@babel/core@7.23.9)
-      '@types/ember': 4.0.6(@babel/core@7.23.9)
-      '@types/ember__engine': 4.0.7(@babel/core@7.23.9)
-      '@types/ember__object': 4.0.8(@babel/core@7.23.9)
+      '@types/ember': 4.0.6
+      '@types/ember__engine': 4.0.7
+      '@types/ember__object': 4.0.8
       '@types/ember__owner': 4.0.6
-      '@types/ember__routing': 4.0.16(@babel/core@7.23.9)
+      '@types/ember__routing': 4.0.16
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -2890,10 +2897,17 @@ packages:
     resolution: {integrity: sha512-17tuhICdjh3UoGBKO7We3J58iXuhFuDIRPVNY9GpvayOMGiVkBOMLpaLpu3FpRppJ3qu0UkpwA06uHmcGoBT5g==}
     dependencies:
       '@types/ember': 4.0.6(@babel/core@7.23.9)
-      '@types/ember__object': 4.0.8(@babel/core@7.23.9)
+      '@types/ember__object': 4.0.8
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
+    dev: true
+
+  /@types/ember__component@4.0.22:
+    resolution: {integrity: sha512-m72EtmBN/RxOChXqRsyOg4RR5+AiB4LQ8s1CEKNYAfvANt18m4hjqxtA7QZYLTq2ZjEVJGpdMsrdDuONWjwRSQ==}
+    dependencies:
+      '@types/ember': 4.0.6(@babel/core@7.23.9)
+      '@types/ember__object': 4.0.8
     dev: true
 
   /@types/ember__component@4.0.22(@babel/core@7.23.9):
@@ -2906,37 +2920,35 @@ packages:
       - supports-color
     dev: true
 
-  /@types/ember__controller@4.0.8(@babel/core@7.23.9):
+  /@types/ember__controller@4.0.8:
     resolution: {integrity: sha512-5CdPyjpYLvflbPvInIS4ukU6fdusJavVzPnPhTvojG1Nny+eLli5xqGaRWE3itt7ElcPsmi55XfrUQI4lgAFJg==}
     dependencies:
-      '@types/ember__object': 4.0.8(@babel/core@7.23.9)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
+      '@types/ember__object': 4.0.8
     dev: true
 
-  /@types/ember__debug@4.0.5(@babel/core@7.23.9):
+  /@types/ember__debug@4.0.5:
     resolution: {integrity: sha512-KBEEHws6CClZR7tpIplURyuKSkQhW6ZHsPWvRxTRr5104V0X+jUvv2ef/JZ35YUp01oS4DXqvn6DwCkhZOy0KA==}
     dependencies:
-      '@types/ember__object': 4.0.8(@babel/core@7.23.9)
+      '@types/ember__object': 4.0.8
       '@types/ember__owner': 4.0.6
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
     dev: true
 
-  /@types/ember__engine@4.0.7(@babel/core@7.23.9):
+  /@types/ember__engine@4.0.7:
     resolution: {integrity: sha512-AxIrs9bsmgup7da6GHNFI6iU/YiUWhme3RRFID7eEU21tGtT2JjlHz1i2TxSk9SKYkUvpoTYR+nnxlpOD3VheA==}
     dependencies:
-      '@types/ember__object': 4.0.8(@babel/core@7.23.9)
+      '@types/ember__object': 4.0.8
       '@types/ember__owner': 4.0.6
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
     dev: true
 
   /@types/ember__error@4.0.3:
     resolution: {integrity: sha512-lQ/ZrPS5s7LjYhML8TCfcKyMumAy7Hh+9CI66WShHumuojSZZm36LhpaUXC0sMf5uF3uKimaVrvvvrvBLDePZg==}
+    dev: true
+
+  /@types/ember__object@4.0.8:
+    resolution: {integrity: sha512-ZpMUVWnOr/FespCyriI2I3PvvJLUVkVZx8tlCFql9Cd3dqMF1O4RN4IdaFTWHcT/4rNdjAFKF5CxzoVSzKU/9A==}
+    dependencies:
+      '@types/ember': 4.0.6
+      '@types/rsvp': 4.0.5
     dev: true
 
   /@types/ember__object@4.0.8(@babel/core@7.23.9):
@@ -2957,16 +2969,31 @@ packages:
     resolution: {integrity: sha512-B/UF8BlQGKo5ixqfNI8D3E3wrR/Nxf6c9Z4f10IdVE5oeRUs8cciY4S1xImoYZQ3QhZKvXDUh1Tpr2S3QqHIxw==}
     dev: true
 
+  /@types/ember__routing@4.0.16:
+    resolution: {integrity: sha512-ydxQ7LVkkNEsnibnRX8hofF/6uHFRwdbTfS3o3pHC5rchfhEg2/G2hPOdF60UIikTcn6JfekjViz+HDwNwqUQw==}
+    dependencies:
+      '@types/ember': 4.0.6
+      '@types/ember__controller': 4.0.8
+      '@types/ember__object': 4.0.8
+      '@types/ember__service': 4.0.5
+    dev: true
+
   /@types/ember__routing@4.0.16(@babel/core@7.23.9):
     resolution: {integrity: sha512-ydxQ7LVkkNEsnibnRX8hofF/6uHFRwdbTfS3o3pHC5rchfhEg2/G2hPOdF60UIikTcn6JfekjViz+HDwNwqUQw==}
     dependencies:
       '@types/ember': 4.0.6(@babel/core@7.23.9)
-      '@types/ember__controller': 4.0.8(@babel/core@7.23.9)
-      '@types/ember__object': 4.0.8(@babel/core@7.23.9)
-      '@types/ember__service': 4.0.5(@babel/core@7.23.9)
+      '@types/ember__controller': 4.0.8
+      '@types/ember__object': 4.0.8
+      '@types/ember__service': 4.0.5
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
+    dev: true
+
+  /@types/ember__runloop@4.0.6:
+    resolution: {integrity: sha512-Lh/4ViAiD4xcAEyhcTjz3p79j7cQSHc2Y+eZZyXhASugHjdKI5e0SzpZTWiJipE4n6aqB68BTdhiu5K8p5Zbrg==}
+    dependencies:
+      '@types/ember': 4.0.6
     dev: true
 
   /@types/ember__runloop@4.0.6(@babel/core@7.23.9):
@@ -2978,13 +3005,10 @@ packages:
       - supports-color
     dev: true
 
-  /@types/ember__service@4.0.5(@babel/core@7.23.9):
+  /@types/ember__service@4.0.5:
     resolution: {integrity: sha512-olpjH+VrWJCeEDyy0/YJ4iv7K9XXgn0JO44+smuCOinWEUSyEehPb40bn4ol4KKIK02cPJgA8aYi0Fy0jebOsg==}
     dependencies:
-      '@types/ember__object': 4.0.8(@babel/core@7.23.9)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
+      '@types/ember__object': 4.0.8
     dev: true
 
   /@types/ember__string@3.0.11:
@@ -3004,6 +3028,12 @@ packages:
       - supports-color
     dev: true
 
+  /@types/ember__utils@4.0.4:
+    resolution: {integrity: sha512-RP6Phi3/oYskNxrH2rm4ZK0yNjxCRKRyY0A796gE2Mv31S6+kkRobqZ/LpH9bVa2FUgdl/4XZIyX/W4L1UWwig==}
+    dependencies:
+      '@types/ember': 4.0.6
+    dev: true
+
   /@types/ember__utils@4.0.4(@babel/core@7.23.9):
     resolution: {integrity: sha512-RP6Phi3/oYskNxrH2rm4ZK0yNjxCRKRyY0A796gE2Mv31S6+kkRobqZ/LpH9bVa2FUgdl/4XZIyX/W4L1UWwig==}
     dependencies:
@@ -3020,12 +3050,8 @@ packages:
       '@types/json-schema': 7.0.13
     dev: true
 
-  /@types/estree@1.0.5:
-    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
-
   /@types/estree@1.0.6:
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
-    dev: true
 
   /@types/express-serve-static-core@4.17.37:
     resolution: {integrity: sha512-ZohaCYTgGFcOP7u6aJOhY9uIZQgZ2vxC2yWoArY+FeDXlqeH66ZVBjgvg+RLVAS/DWNq4Ap9ZXu1+SUQiiWYMg==}
@@ -3145,10 +3171,6 @@ packages:
     resolution: {integrity: sha512-Vhmt0IASo026ZU20O3KP1nBZOCXduQ/Ei+vpgs0hfDZHysSIfhnMc61ZMIUuaazfYS0J9EhLz+jJsft6iYX4Kw==}
     dev: true
 
-  /@types/semver@7.5.3:
-    resolution: {integrity: sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==}
-    dev: true
-
   /@types/semver@7.5.8:
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
     dev: true
@@ -3193,8 +3215,8 @@ packages:
       graphemer: 1.4.0
       ignore: 5.2.4
       natural-compare: 1.4.0
-      semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.6.2)
+      semver: 7.6.3
+      ts-api-utils: 1.3.0(typescript@5.6.2)
       typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
@@ -3222,8 +3244,8 @@ packages:
       graphemer: 1.4.0
       ignore: 5.2.4
       natural-compare: 1.4.0
-      semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.6.2)
+      semver: 7.6.3
+      ts-api-utils: 1.3.0(typescript@5.6.2)
       typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
@@ -3369,7 +3391,7 @@ packages:
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
       '@types/json-schema': 7.0.13
-      '@types/semver': 7.5.3
+      '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.6.2)
@@ -6167,46 +6189,6 @@ packages:
   /electron-to-chromium@1.4.643:
     resolution: {integrity: sha512-QHscvvS7gt155PtoRC0dR2ilhL8E9LHhfTQEq1uD5AL0524rBLAwpAREFH06f87/e45B9XkR6Ki5dbhbCsVEIg==}
 
-  /ember-auto-import@2.6.3(@glint/template@1.4.0)(webpack@5.94.0):
-    resolution: {integrity: sha512-uLhrRDJYWCRvQ4JQ1e64XlSrqAKSd6PXaJ9ZsZI6Tlms9T4DtQFxNXasqji2ZRJBVrxEoLCRYX3RTldsQ0vNGQ==}
-    engines: {node: 12.* || 14.* || >= 16}
-    dependencies:
-      '@babel/core': 7.23.9
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.23.9)
-      '@babel/plugin-proposal-decorators': 7.23.9(@babel/core@7.23.9)
-      '@babel/preset-env': 7.22.20(@babel/core@7.23.9)
-      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
-      '@embroider/shared-internals': 2.6.2
-      babel-loader: 8.3.0(@babel/core@7.23.9)(webpack@5.94.0)
-      babel-plugin-ember-modules-api-polyfill: 3.5.0
-      babel-plugin-ember-template-compilation: 2.2.0
-      babel-plugin-htmlbars-inline-precompile: 5.3.1
-      babel-plugin-syntax-dynamic-import: 6.18.0
-      broccoli-debug: 0.6.5
-      broccoli-funnel: 3.0.8
-      broccoli-merge-trees: 4.2.0
-      broccoli-plugin: 4.0.7
-      broccoli-source: 3.0.1
-      css-loader: 5.2.7(webpack@5.94.0)
-      debug: 4.3.4
-      fs-extra: 10.1.0
-      fs-tree-diff: 2.0.1
-      handlebars: 4.7.8
-      js-string-escape: 1.0.1
-      lodash: 4.17.21
-      mini-css-extract-plugin: 2.7.6(webpack@5.94.0)
-      parse5: 6.0.1
-      resolve: 1.22.6
-      resolve-package-path: 4.0.3
-      semver: 7.6.3
-      style-loader: 2.0.0(webpack@5.94.0)
-      typescript-memoize: 1.1.1
-      walk-sync: 3.0.0
-    transitivePeerDependencies:
-      - '@glint/template'
-      - supports-color
-      - webpack
-
   /ember-auto-import@2.7.2(@glint/template@1.4.0)(webpack@5.94.0):
     resolution: {integrity: sha512-pkWIljmJClYL17YBk8FjO7NrZPQoY9v0b+FooJvaHf/xlDQIBYVP7OaDHbNuNbpj7+wAwSDAnnwxjCoLsmm4cw==}
     engines: {node: 12.* || 14.* || >= 16}
@@ -6218,7 +6200,7 @@ packages:
       '@babel/plugin-transform-class-static-block': 7.22.11(@babel/core@7.23.9)
       '@babel/preset-env': 7.22.20(@babel/core@7.23.9)
       '@embroider/macros': 1.16.5(@glint/template@1.4.0)
-      '@embroider/shared-internals': 2.5.1
+      '@embroider/shared-internals': 2.6.2
       babel-loader: 8.3.0(@babel/core@7.23.9)(webpack@5.94.0)
       babel-plugin-ember-modules-api-polyfill: 3.5.0
       babel-plugin-ember-template-compilation: 2.2.0
@@ -6241,7 +6223,7 @@ packages:
       parse5: 6.0.1
       resolve: 1.22.6
       resolve-package-path: 4.0.3
-      semver: 7.5.4
+      semver: 7.6.3
       style-loader: 2.0.0(webpack@5.94.0)
       typescript-memoize: 1.1.1
       walk-sync: 3.0.0
@@ -6249,7 +6231,6 @@ packages:
       - '@glint/template'
       - supports-color
       - webpack
-    dev: true
 
   /ember-cli-app-version@6.0.1(ember-source@4.12.2):
     resolution: {integrity: sha512-XA1FwkWA5QytmWF0jcJqEr3jcZoiCl9Fb33TZgOVfClL7Voxe+/RwzISEprBRQgbf7j8z1xf8/RJCKfclUy3rQ==}
@@ -6338,7 +6319,7 @@ packages:
       ember-cli-version-checker: 5.1.2
       ensure-posix-path: 1.1.1
       resolve-package-path: 4.0.3
-      semver: 7.5.4
+      semver: 7.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6377,7 +6358,7 @@ packages:
       hash-for-dep: 1.5.1
       heimdalljs-logger: 0.1.10
       js-string-escape: 1.0.1
-      semver: 7.5.4
+      semver: 7.6.3
       silent-error: 1.1.1
       walk-sync: 2.2.0
     transitivePeerDependencies:
@@ -6506,7 +6487,7 @@ packages:
       fs-extra: 9.1.0
       resolve: 1.22.6
       rsvp: 4.8.5
-      semver: 7.5.4
+      semver: 7.6.3
       stagehand: 1.0.1
       walk-sync: 2.2.0
     transitivePeerDependencies:
@@ -6617,7 +6598,7 @@ packages:
       resolve-package-path: 4.0.3
       safe-stable-stringify: 2.4.3
       sane: 5.0.1
-      semver: 7.5.4
+      semver: 7.6.3
       silent-error: 1.1.1
       sort-package-json: 1.57.0
       symlink-or-copy: 1.3.1
@@ -6887,7 +6868,7 @@ packages:
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
-      ember-auto-import: 2.6.3(@glint/template@1.4.0)(webpack@5.94.0)
+      ember-auto-import: 2.7.2(@glint/template@1.4.0)(webpack@5.94.0)
       ember-cli-babel: 7.26.11
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0
@@ -6899,7 +6880,7 @@ packages:
       ember-router-generator: 2.0.0
       inflection: 1.13.4
       resolve: 1.22.6
-      semver: 7.5.4
+      semver: 7.6.3
       silent-error: 1.1.1
     transitivePeerDependencies:
       - '@babel/core'
@@ -6997,7 +6978,7 @@ packages:
       fs-extra: 6.0.1
       resolve: 1.22.6
       rimraf: 3.0.2
-      semver: 7.5.4
+      semver: 7.6.3
       walk-sync: 2.2.0
     transitivePeerDependencies:
       - encoding
@@ -7411,6 +7392,7 @@ packages:
   /eslint@8.56.0:
     resolution: {integrity: sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
@@ -7722,17 +7704,6 @@ packages:
 
   /fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
-    dev: true
-
-  /fast-glob@3.3.1:
-    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
-    engines: {node: '>=8.6.0'}
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.5
     dev: true
 
   /fast-glob@3.3.2:
@@ -8581,7 +8552,7 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       dir-glob: 3.0.1
-      fast-glob: 3.3.1
+      fast-glob: 3.3.2
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 4.0.0
@@ -10204,6 +10175,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+    dev: true
 
   /lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
@@ -12363,6 +12335,7 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+    dev: true
 
   /semver@7.6.3:
     resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
@@ -13380,15 +13353,6 @@ packages:
       - supports-color
     dev: true
 
-  /ts-api-utils@1.0.3(typescript@5.6.2):
-    resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
-    engines: {node: '>=16.13.0'}
-    peerDependencies:
-      typescript: '>=4.2.0'
-    dependencies:
-      typescript: 5.6.2
-    dev: true
-
   /ts-api-utils@1.3.0(typescript@5.6.2):
     resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
     engines: {node: '>=16'}
@@ -13896,7 +13860,7 @@ packages:
       webpack-cli:
         optional: true
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       '@webassemblyjs/ast': 1.12.1
       '@webassemblyjs/wasm-edit': 1.12.1
       '@webassemblyjs/wasm-parser': 1.12.1
@@ -14134,6 +14098,7 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    dev: true
 
   /yam@1.0.0:
     resolution: {integrity: sha512-Hv9xxHtsJ9228wNhk03xnlDReUuWVvHwM4rIbjdAXYvHLs17xjuyF50N6XXFMN6N0omBaqgOok/MCK3At9fTAg==}


### PR DESCRIPTION
Embroider updates were blocked and a solution proposed was to use `pnpm dedupe`