### PR TITLE
Allow Ember v6

### DIFF
--- a/ember-autofocus-modifier/package.json
+++ b/ember-autofocus-modifier/package.json
@@ -68,7 +68,7 @@
     "typescript": "^5.6.2"
   },
   "peerDependencies": {
-    "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
+    "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Fixes dependency tree warnings when installed in Ember v6 app