### PR TITLE
fix: authenticate pnpm with npm registry before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,13 @@ jobs:
         uses: wyvox/action-setup-pnpm@v3
         with:
           node-version: 22.x
-          node-registry-url: "https://registry.npmjs.org"
+
+      - name: Authenticate with npm registry
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Trigger release script
         run: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description

The release workflow was failing with `ERROR Not authenticated with pnpm` because pnpm does not read the `NODE_AUTH_TOKEN` environment variable — it only reads auth from `.npmrc`.

The fix writes the token directly into `~/.npmrc` as `//registry.npmjs.org/:_authToken=...` before the release step runs, which is how pnpm resolves registry auth.

The now-unused `node-registry-url` option on the setup step is also removed since pnpm ignores it.

## Reproduction Instructions

Trigger the release workflow without this fix — it will fail immediately after `pnpm run release` with an authentication error.