### PR TITLE
revert: npm auth fix + bump all jobs to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install pnpm
         uses: wyvox/action-setup-pnpm@v3
         with:
-          node-version: node24
+          node-version: 24.x
           args: "--frozen-lockfile"
       - name: Lint
         run: pnpm lint
@@ -39,7 +39,7 @@ jobs:
       - name: Install pnpm
         uses: wyvox/action-setup-pnpm@v3
         with:
-          node-version: node24
+          node-version: 24.x
           args: "--no-lockfile"
       - name: Run tests
         run: pnpm test
@@ -66,7 +66,7 @@ jobs:
       - name: Install pnpm
         uses: wyvox/action-setup-pnpm@v3
         with:
-          node-version: node24
+          node-version: 24.x
           args: "--frozen-lockfile"
       - name: Run tests
         run: pnpm ember try:one ${{ matrix.ember-try-scenario }} --skip-cleanup
@@ -91,7 +91,7 @@ jobs:
       - name: Install pnpm
         uses: wyvox/action-setup-pnpm@v3
         with:
-          node-version: node24
+          node-version: 24.x
           args: "--frozen-lockfile"
       - name: Update TS version on addon package
         run: pnpm add -D ${{ matrix.typescript-scenario }} --ignore-scripts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install pnpm
         uses: wyvox/action-setup-pnpm@v3
         with:
-          node-version: 22.x
+          node-version: node24
           args: "--frozen-lockfile"
       - name: Lint
         run: pnpm lint
@@ -39,7 +39,7 @@ jobs:
       - name: Install pnpm
         uses: wyvox/action-setup-pnpm@v3
         with:
-          node-version: 22.x
+          node-version: node24
           args: "--no-lockfile"
       - name: Run tests
         run: pnpm test
@@ -66,7 +66,7 @@ jobs:
       - name: Install pnpm
         uses: wyvox/action-setup-pnpm@v3
         with:
-          node-version: 22.x
+          node-version: node24
           args: "--frozen-lockfile"
       - name: Run tests
         run: pnpm ember try:one ${{ matrix.ember-try-scenario }} --skip-cleanup
@@ -91,7 +91,7 @@ jobs:
       - name: Install pnpm
         uses: wyvox/action-setup-pnpm@v3
         with:
-          node-version: 22.x
+          node-version: node24
           args: "--frozen-lockfile"
       - name: Update TS version on addon package
         run: pnpm add -D ${{ matrix.typescript-scenario }} --ignore-scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install pnpm
         uses: wyvox/action-setup-pnpm@v3
         with:
-          node-version: node24
+          node-version: 24.x
           node-registry-url: "https://registry.npmjs.org"
 
       - name: Trigger release script

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,10 @@ jobs:
         uses: wyvox/action-setup-pnpm@v3
         with:
           node-version: 22.x
-
-      - name: Authenticate with npm registry
-        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          node-registry-url: "https://registry.npmjs.org"
 
       - name: Trigger release script
         run: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install pnpm
         uses: wyvox/action-setup-pnpm@v3
         with:
-          node-version: 22.x
+          node-version: node24
           node-registry-url: "https://registry.npmjs.org"
 
       - name: Trigger release script


### PR DESCRIPTION
## Description

Two changes:

**1. Reverts #732** — the `~/.npmrc` approach did not fix the pnpm authentication error, so that change is reverted.

**2. Bumps all CI and release jobs to Node 24** (`node24`) — both `ci.yml` and `release.yml` now use `node-version: node24` across every job.

## Resources
- #732