### PR TITLE
fix(release): disable frozen-lockfile to fix release-it workspaces install

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 resolution-mode=highest
+frozen-lockfile=false


### PR DESCRIPTION
## Summary
- The `release` GH Action was failing during release-it's workspaces plugin bump step: it updates `test-app/package.json`'s dependency on `ember-autofocus-modifier` to the new version, then runs its own internal `pnpm install` — before our `after:bump` hook (`pnpm i --frozen-lockfile=false`) ever runs.
- In CI, pnpm defaults to `frozen-lockfile=true`, so that internal install fails because `pnpm-lock.yaml` hasn't caught up with the just-bumped `package.json` yet.
- Adds `frozen-lockfile=false` to `.npmrc` so this default applies to that internal install call. CI's explicit `--frozen-lockfile` steps in `ci.yml` are unaffected since the CLI flag overrides the `.npmrc` default.

## Test plan
- [ ] Re-run the `release` workflow and confirm `release-it`'s workspaces plugin `npm version` step no longer fails with `ERR_PNPM_OUTDATED_LOCKFILE`
- [ ] Confirm regular CI (`ci.yml`) still enforces frozen lockfile on PRs (i.e. this doesn't mask real lockfile drift outside the release flow)